### PR TITLE
fix: agrega node-modules a mdlintignore, porque windows

### DIFF
--- a/.mdlintignore
+++ b/.mdlintignore
@@ -1,4 +1,3 @@
-node_modules/
 **/node_modules/
 tmp/
 projects/learning-objectives.md

--- a/.mdlintignore
+++ b/.mdlintignore
@@ -1,4 +1,4 @@
-**/node_modules/
+node_modules/**
 tmp/
 projects/learning-objectives.md
 /README.md

--- a/.mdlintignore
+++ b/.mdlintignore
@@ -1,3 +1,4 @@
+node_modules/
 **/node_modules/
 tmp/
 projects/learning-objectives.md


### PR DESCRIPTION
`npm run mdlint` en Windows resalta errores en `node_modules` , en la raiz de repo, cuando debe ignorarlo con `.mdlintignore`

Creo el glob `**/node_modules` que sirve en Unix match cualquier directorio `node_modules` en el arbol de proyecto, no hace match con el `node_modules` al raiz de proyecto en Windows, y por eso en Windows `mdlint` chequea este directorio.

Para probar -
Agrega este linea o tu `.mdlintignore` y hace cambios de readme o un markdown y corre `npm run mdlint`.
Deberia solo resaltar el cambio que hiciste y no todo los cambios en `node_modules/`