### PR TITLE
fix(Projects): Muestra íconos de Objetivos de Aprendizaje sólo si existen

### DIFF
--- a/src/components/Track/Projects.jsx
+++ b/src/components/Track/Projects.jsx
@@ -47,7 +47,7 @@ const Project = ({ lang, project }) => {
           <span>
             {learningObjectiveCats.map(cat => {
               const icon = learningObjectiveToIcon(cat);
-              return (
+              return icon && (
                 <span
                   key={`icon-${cat}`}
                   title={cat}

--- a/src/lib/learning-objectives.js
+++ b/src/lib/learning-objectives.js
@@ -163,5 +163,5 @@ const learningObjectivesIcons = {
 };
 
 export const learningObjectiveToIcon = (key) => {
-  return learningObjectivesIcons[key] || {};
+  return learningObjectivesIcons[key] || undefined;
 };


### PR DESCRIPTION
Closes #1520 

Con este _fix_, ahora sólo se despliegan los íconos que sí existen, si no existe el ícono, no agrega el espacio ni el tooltip ni nada, y con eso el sitio ya no se siente "roto".

![Screenshot_2023-09-06_15-14-17](https://github.com/Laboratoria/curriculum/assets/12631491/4f1c9b5e-1309-4d3b-9ed7-8a73b3f1afab)
