### PR TITLE
fix the description of panel specifying use promises in the request

### DIFF
--- a/projects/03-dataverse-chat/README.md
+++ b/projects/03-dataverse-chat/README.md
@@ -151,11 +151,14 @@ de lo que estas máquinas podrían lograr me impulsaron a seguir adelante."
     personajes/entidades en un cuadro de texto y enviarlo con un botón
   - El mensaje de la usuaria debe ser ajustado para cada personaje/entidad,
     con el objetivo que este genere una respuesta basada en su personalidad
-    y conocimiento
+    y conocimiento, el prompt que usaras sera de forma individual para cada personaje
+    empleando una promesa dedicada para cada petición, asegurándote de que todas las
+    promesas se completen de manera simultanea.
   - Las respuestas de todos los personajes se muestran de acuerdo al orden
     respuesta.
   - Indicar visualmente cuando uno o varios personajes/entidades esten
-    generando una respuesta al mensaje enviado
+    generando una respuesta al mensaje enviado.
+
 * La aplicación debe informar a la usuaria los errores que puedan surgir al
   interactuar con la API, como por ejemplo alcanzar la cuota de tokens por
   minuto o cualquier otro error relacionado con la API. Debería


### PR DESCRIPTION
This PR #1682 is for add specify the use of promises for the panel because in dev012 I had OH with a student who implemented only one prompt on the panel and the statement includes a string with all characters of her data, her prompt sounded: `Act as Homer, Marge, Bart, Lisa, Maggie... and answer the next question: ${question}`.
