### PR TITLE
feat(projects/fleet-management-api): Cambia sintaxis de OAs a objeto sin anidación

### DIFF
--- a/projects/05-fleet-management-api/project.yml
+++ b/projects/05-fleet-management-api/project.yml
@@ -27,17 +27,16 @@ variants:
       # Cualquier OA puede expresarse como objeto, por ejemplo para flaggear
       # como "opcional".
       # por ahora es la unica propiedad soportada.
-      - object-oriented-programming:
-          optional: true
+      - id: object-oriented-programming
+        optional: true
+  - name: node-mongodb
+    learningObjectives:
+      - node
+      - mongodb
+      - id: sql
+        exclude: true
   - name: python
     learningObjectives:
       - python
-      - object-oriented-programming:
-          optional: true
-  - name: python-django
-    learningObjectives:
-      - python
-      - django      
-      # Además se pueden "apagar" OAs "default" seteando el OA a "false"
-      - sql: false
-      - db: false
+      - id: object-oriented-programming
+        optional: true


### PR DESCRIPTION
Este cambio propone que a partir de ahora los objetivos de aprendizaje (ya sean generales o de variante) se puedan expresar o como strings (estilo _legacy_) o como objetos. Cuando se expresen como objetos será obligatorio que contengan la propiedad `id` con el string que hubiéramos usado en estilo _legacy_ y opcionalmente podría tener las siguientes propiedades:

- `optional`: Por defecto `false`. Solo necesaria cuando queramos que sea `true`.
- `exlude`: Solo se puede usar dentro de los objetivos de las variantes, cuando queramos excluir objetivos declarados a nivel de todo el proyecto. Por defecto `false`. Solo necesaria cuando queramos que sea `true`.

Con el formato propuesto originalmente estábamos declarando OAs como objetos donde la única llave era el identificador del OA y el valor otro objeto anidado con las props como `optional` y `exclude` (innecesariamente verbose y más complejo de parsear). Por ejemplo:

```yaml
learningObjectives:
  - html
  - css
  - dom:
    - optional: true
```

Esto en JSON se transforma en:

```json
{
  "learningObjectives": [
    "html",
    "css",
    { "dom": { "optional": true  } }
  ]
}
```

***

# Ejemplos de sintaxis propuesta

## Ejemplo estilo legacy (OAs como strings)

```yml
learningObjectives:
  - html
  - css
  - dom
```

## Ejemplo OAs como objetos

```yml
learningObjectives:
  - id: html
  - id: css
  - id: dom
    optional: true
```

## Ejemplo mezclando ambos estilos

```yml
learningObjectives:
  - html
  - css
  - id: dom
    optional: true
```