### PR TITLE
fix: remove blank links from devops objectives es.yml

### DIFF
--- a/learning-objectives/intl/es.yml
+++ b/learning-objectives/intl/es.yml
@@ -2079,16 +2079,10 @@ devops/container-cloud-services:
 devops/container-cloud-services/orchestration-system-components:
   title: Describir los componentes clave de un sistema de orquestación, como clústeres, tareas, servicios y balanceadores de carga
   description: Describir los componentes clave de un sistema de orquestación, como clústeres, tareas, servicios y balanceadores de carga
-  links:
-    - title:
-      url:  
 
 devops/container-cloud-services/configure-container-task-definitions:
   title: Crear y configurar definiciones de contenedor y tareas que incluyan todos los componentes necesarios para ejecutar un aplicación, como imágenes Docker, variables de entorno, volúmenes y configuraciones de red
   description: Crear y configurar definiciones de contenedor y tareas que incluyan todos los componentes necesarios para ejecutar un aplicación, como imágenes Docker, variables de entorno, volúmenes y configuraciones de red
-  links:
-    - title:
-      url:  
 
 devops/kubernetes:
   title: Kubernetes
@@ -2098,8 +2092,8 @@ devops/kubernetes/kubernetes-use-cases:
   title: Explicar que es Kubernetes y describir sus casos de uso y las necesidades que soluciona
   description: Explicar que es Kubernetes y describir sus casos de uso y las necesidades que soluciona
   links:
-    - title:
-      url:  
+    - title: Kubernetes
+      url:  https://kubernetes.io/
 
 data-analytics:
   title: Análisis de datos


### PR DESCRIPTION
Hotfix, no links in devops OAs are killing the project page.

https://bootcamp.laboratoria.la/es/projects/container-service-deployment?version=v9.4.0